### PR TITLE
Fixes for closing a connection

### DIFF
--- a/aiossdb/__init__.py
+++ b/aiossdb/__init__.py
@@ -4,7 +4,7 @@ from .parser import SSDBParser
 from .pool import create_pool, SSDBConnectionPool
 from .client import Client
 
-__version__ = '0.0.2'
+__version__ = '0.0.9'
 __author__ = 'Kevin Du'
 __email__ = 'dgt_x@foxmail.com'
 __licence__ = 'MIT'

--- a/aiossdb/__init__.py
+++ b/aiossdb/__init__.py
@@ -4,7 +4,7 @@ from .parser import SSDBParser
 from .pool import create_pool, SSDBConnectionPool
 from .client import Client
 
-__version__ = '0.0.9'
+__version__ = '0.0.11'
 __author__ = 'Kevin Du'
 __email__ = 'dgt_x@foxmail.com'
 __licence__ = 'MIT'

--- a/aiossdb/__init__.py
+++ b/aiossdb/__init__.py
@@ -4,7 +4,7 @@ from .parser import SSDBParser
 from .pool import create_pool, SSDBConnectionPool
 from .client import Client
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 __author__ = 'Kevin Du'
 __email__ = 'dgt_x@foxmail.com'
 __licence__ = 'MIT'

--- a/aiossdb/connection.py
+++ b/aiossdb/connection.py
@@ -98,7 +98,9 @@ class SSDBConnection:
         self._closed = False
 
     def __repr__(self):
-        return '<SSDBConnection [host:{}-port:{}]>'.format(self._address[0], self._address[1])
+        return f'<SSDBConnection ' \
+               f'[host:{self._address[0]}-port:{self._address[1]}' \
+               f'-closing:{self._closing}-closed:{self._closed}]>'
 
     async def _read_data(self):
         # 在一个套接字生存期中，无限循环，直到断开连接，接收到EOF字符
@@ -156,7 +158,6 @@ class SSDBConnection:
             raise TypeError("args must not contain None")
         # 命令推荐小写
         command = command.lower().strip()
-
         future = asyncio.Future(loop=self._loop)
         # 将命令和参数编码成协议要求的格式
         self._writer.write(encode_command(command, *args))

--- a/aiossdb/log.py
+++ b/aiossdb/log.py
@@ -1,14 +1,14 @@
-import os
-import sys
+# import os
+# import sys
 import logging
 
 
 logger = logging.getLogger('aiossdb')
 
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(stream=sys.stderr)
-handler.setFormatter(logging.Formatter(
-    "%(asctime)s %(name)s %(levelname)s %(message)s"))
-logger.addHandler(handler)
-os.environ["AIOSSDB_DEBUG"] = ""
+# logger.setLevel(logging.DEBUG)
+# handler = logging.StreamHandler(stream=sys.stderr)
+# handler.setFormatter(logging.Formatter(
+#     "%(asctime)s %(name)s %(levelname)s %(message)s"))
+# logger.addHandler(handler)
+# os.environ["AIOSSDB_DEBUG"] = ""
 

--- a/aiossdb/log.py
+++ b/aiossdb/log.py
@@ -1,14 +1,14 @@
-# import os
-# import sys
+import os
+import sys
 import logging
 
 
 logger = logging.getLogger('aiossdb')
 
-# if os.environ.get("AIOSSDB_DEBUG"):
-#     logger.setLevel(logging.DEBUG)
-#     handler = logging.StreamHandler(stream=sys.stderr)
-#     handler.setFormatter(logging.Formatter(
-#         "%(asctime)s %(name)s %(levelname)s %(message)s"))
-#     logger.addHandler(handler)
-#     os.environ["AIOSSDB_DEBUG"] = ""
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(stream=sys.stderr)
+handler.setFormatter(logging.Formatter(
+    "%(asctime)s %(name)s %(levelname)s %(message)s"))
+logger.addHandler(handler)
+os.environ["AIOSSDB_DEBUG"] = ""
+

--- a/aiossdb/parser.py
+++ b/aiossdb/parser.py
@@ -94,8 +94,10 @@ class SSDBParser:
         size = yield from self.read_int()
         status = (yield from self.read_line(size)).decode(self._sys_encoding)
         if status == 'not_found':
+            self.buf = bytearray()
             return None
         if status != 'ok':
+            self.buf = bytearray()
             return ReplyError(status)
         data = []
         try:

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -6,7 +6,7 @@ from .errors import PoolClosedError
 from .log import logger
 
 
-async def create_pool(address, *, password=None, encoding='utf-8', minsize=0, maxsize=10,
+async def create_pool(address, *, password=None, encoding='utf-8', minsize=1, maxsize=10,
                       parser=None, loop=None, timeout=None, pool_cls=None, connection_cls=None):
     if pool_cls is None:
         pool_cls = SSDBConnectionPool

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -6,7 +6,7 @@ from .errors import PoolClosedError
 from .log import logger
 
 
-async def create_pool(address, *, password=None, encoding='utf-8', minsize=1, maxsize=10,
+async def create_pool(address, *, password=None, encoding='utf-8', minsize=0, maxsize=10,
                       parser=None, loop=None, timeout=None, pool_cls=None, connection_cls=None):
     if pool_cls is None:
         pool_cls = SSDBConnectionPool

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -142,7 +142,7 @@ class SSDBConnectionPool:
             return
         if overall:
             # 一直填充到可用连接池中有连接，并且size应该小于最大size
-            while self.size < self.maxsize:
+            while not self._pool and self.size < self.maxsize:
                 try:
                     conn = await create_connection(
                         self._address, password=self._password, encoding=self._encoding, parser=self._parser_class,

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -159,7 +159,8 @@ class SSDBConnectionPool:
         # 关闭的时候已经清空pool和used了
         if self.closed:
             raise PoolClosedError("Pool is closed")
-        # assert conn in self._used, ("Invalid connection, maybe from other pool", conn)
+
+        assert conn in self._used, ("Invalid connection, maybe from other pool", conn)
         if conn in self._used:
             self._used.remove(conn)
         # 如果连接还未关闭，则置入可用连接池

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -159,8 +159,9 @@ class SSDBConnectionPool:
         # 关闭的时候已经清空pool和used了
         if self.closed:
             raise PoolClosedError("Pool is closed")
-        assert conn in self._used, ("Invalid connection, maybe from other pool", conn)
-        self._used.remove(conn)
+        # assert conn in self._used, ("Invalid connection, maybe from other pool", conn)
+        if conn in self._used:
+            self._used.remove(conn)
         # 如果连接还未关闭，则置入可用连接池
         if not conn.closed:
             self._pool.append(conn)

--- a/aiossdb/pool.py
+++ b/aiossdb/pool.py
@@ -142,7 +142,7 @@ class SSDBConnectionPool:
             return
         if overall:
             # 一直填充到可用连接池中有连接，并且size应该小于最大size
-            while not self._pool and self.size < self.maxsize:
+            while self.size < self.maxsize:
                 try:
                     conn = await create_connection(
                         self._address, password=self._password, encoding=self._encoding, parser=self._parser_class,


### PR DESCRIPTION
Connections were being closed due to the fact that the empty response from the backend was not correctly processed. Also updated the library for compatibility with python 3.8+.